### PR TITLE
Return same locale as current one

### DIFF
--- a/moment.go
+++ b/moment.go
@@ -104,7 +104,7 @@ func (m *Moment) GetTime() time.Time {
 }
 
 func (m *Moment) Now() *Moment {
-	m.time = time.Now()
+	m.time = time.Now().In(m.GetTime().Location())
 
 	return m
 }


### PR DESCRIPTION
When using today, tomorrow or yesterday, the time is based relative to time.Now() which loses the timezone information.

Re-using the current location makes it possible to initialise the moment with a time in any location and after that use the relative time/day of tomorrow, yesterday and today
